### PR TITLE
Release v1.1.2: credential hardening, trace propagation, error-routing fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to OpenBox SDK for Temporal Workflows.
 
+## [1.1.2] - 2026-04-22
+
+### Security
+
+- **API key no longer flows through workflow history.** `send_governance_event` refactored into a `GovernanceActivities` class that holds credentials on `self`; activity inputs carry only `payload`, `timeout`, and `on_api_error`. Before this change, anyone with Describe permissions on the namespace could read the API key from the recorded activity input.
+
+### Added
+
+- W3C trace propagation through Temporal headers, on by default via `enable_trace_propagation=True` on `OpenBoxPlugin` and `create_openbox_worker()`. Uses `temporalio.contrib.opentelemetry.TracingInterceptor` so spans started by the caller stitch to workflow/activity spans on the worker side.
+- `ApplicationError` type constants in `errors.py` (`GOVERNANCE_HALT_ERROR_TYPE`, `GOVERNANCE_BLOCK_ERROR_TYPE`, `GOVERNANCE_API_ERROR_TYPE`, `GOVERNANCE_STOP_ERROR_TYPE`) — single source of truth for governance error routing.
+- `openbox.activities.GovernanceActivities` class + `build_governance_activities()` factory.
+
+### Fixed
+
+- **Workflow exception shadowing** — `WorkflowFailed` event send is now wrapped in `try/except`, so a `GovernanceHaltError` from `fail_closed + API down` no longer replaces the real workflow error.
+- **String-matching on exception types** — `workflow_interceptor` now inspects `ApplicationError.type` via the exception chain instead of `"GovernanceHalt" in str(e)`. Eliminates false positives when a user workflow happens to emit an error message containing a governance keyword.
+- **Race creating governance HTTP client** — `hook_governance._get_sync_client` / `_get_async_client` now use double-checked locking. Previously two concurrent activities could each create a client, with the losing instance getting garbage-collected while its connection pool leaked.
+- **Replayer plugin coverage** — `test_plugin_integration.py` now passes `plugins=[plugin]` to `Replayer`, so replay tests validate interceptor determinism, not just user workflow code.
+- Version-pin mismatch — comments in `openbox/__init__.py` said `temporalio >= 1.24.0` but pyproject/README pin `1.23.0`. Corrected to `1.23.0`.
+
+### Changed
+
+- `plugin.py` / `worker.py` now use `logging.getLogger(__name__)` for initialization status messages instead of `print()`.
+
 ## [1.1.1] - 2026-04-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -52,7 +52,15 @@ await worker.run()
 ```
 
 The plugin automatically configures governance interceptors, OTel instrumentation,
-sandbox passthrough, and the `send_governance_event` activity.
+sandbox passthrough, W3C trace propagation through Temporal headers (via
+`temporalio.contrib.opentelemetry.TracingInterceptor`), and the
+`send_governance_event` activity.
+
+**Credentials never leave the plugin.** `openbox_api_key` is captured on the
+governance activity instance itself — it does **not** flow through activity
+inputs, so it is never written to workflow history. To opt out of trace
+propagation (e.g., if you already wire `OpenTelemetryPlugin`), pass
+`enable_trace_propagation=False`.
 
 ### Composing with Other Plugins
 
@@ -100,8 +108,10 @@ The factory automatically:
 1. Validates the API key
 2. Creates span processor
 3. Sets up OpenTelemetry instrumentation
-4. Creates governance interceptors
-5. Adds `send_governance_event` activity
+4. Creates governance interceptors (incl. W3C trace propagation)
+5. Builds the `GovernanceActivities` instance with credentials captured on
+   `self` and registers its `send_governance_event` method — the API key is
+   never passed through activity inputs / workflow history
 6. Returns fully configured Worker
 
 ---
@@ -146,6 +156,11 @@ worker = create_openbox_worker(
 
     # File I/O instrumentation
     instrument_file_io=False,  # disabled by default
+
+    # Header-based W3C trace propagation (client → workflow → activities).
+    # Default True. Set False if you already wire OpenTelemetryPlugin or a
+    # custom propagator.
+    enable_trace_propagation=True,
 
     # Standard Worker options (all supported)
     activity_executor=my_executor,
@@ -423,7 +438,7 @@ from openbox import (
 )
 from openbox.otel_setup import setup_opentelemetry_for_governance
 from openbox.activity_interceptor import ActivityGovernanceInterceptor
-from openbox.activities import send_governance_event
+from openbox.activities import build_governance_activities
 from openbox.hook_governance import FAIL_OPEN, FAIL_CLOSED  # error policy constants
 
 # 1. Initialize SDK
@@ -463,14 +478,26 @@ activity_interceptor = ActivityGovernanceInterceptor(
     config=config,
 )
 
-# 6. Create worker
+# 6. Build the governance activity instance (credentials captured on `self`
+# so they never flow through workflow history).
+governance_activities = build_governance_activities(
+    api_url="http://localhost:8086",
+    api_key="obx_test_key_1",
+)
+
+# 7. Create worker
 from temporalio.worker import Worker
+from temporalio.contrib.opentelemetry import TracingInterceptor
 worker = Worker(
     client=client,
     task_queue="my-task-queue",
     workflows=[MyWorkflow],
-    activities=[my_activity, send_governance_event],
-    interceptors=[workflow_interceptor, activity_interceptor],
+    activities=[my_activity, governance_activities.send_governance_event],
+    interceptors=[
+        workflow_interceptor,
+        activity_interceptor,
+        TracingInterceptor(),  # W3C header propagation for OTel spans
+    ],
 )
 ```
 

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -83,10 +83,13 @@ This document defines coding standards, architectural patterns, and best practic
 async def execute_workflow(self, input: ExecuteWorkflowInput) -> Any:
     info = workflow.info()
 
-    # Send event via activity (deterministic)
+    # Send event via activity (deterministic). NEVER pass credentials
+    # (api_key) in activity inputs — workflow history is readable by anyone
+    # with Describe permissions on the namespace. The activity holds the
+    # credentials on its instance (see rule 3).
     await workflow.execute_activity(
         "send_governance_event",
-        args=[{"api_url": api_url, "payload": {...}}],
+        args=[{"payload": {...}, "timeout": 30.0, "on_api_error": "fail_open"}],
         start_to_close_timeout=timedelta(seconds=30),
     )
 
@@ -122,25 +125,36 @@ async def execute_workflow(self, input: ExecuteWorkflowInput) -> Any:
 #### Solution: Lazy Imports
 
 ```python
-# ✅ CORRECT - Lazy import in activity function
-@activity.defn(name="send_governance_event")
-async def send_governance_event(input: Dict[str, Any]):
-    import httpx  # ✅ Loaded only when activity executes
-    from datetime import datetime, timezone  # ✅ Lazy import
+# ✅ CORRECT - Class-based activity with credentials captured on self
+class GovernanceActivities:
+    def __init__(self, api_url: str, api_key: str):
+        self._api_url = api_url
+        self._api_key = api_key
 
-    async with httpx.AsyncClient() as client:
-        response = await client.post(...)
-    return response.json()
+    @activity.defn(name="send_governance_event")
+    async def send_governance_event(self, input: Dict[str, Any]):
+        import httpx  # ✅ Loaded only when activity executes
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self._api_url}/api/v1/governance/evaluate",
+                headers={"Authorization": f"Bearer {self._api_key}"},
+                json=input["payload"],
+            )
+        return response.json()
 ```
 
 ```python
-# ❌ WRONG - Module-level import
-import httpx  # ❌ Loaded when module imports, triggers sandbox
-
+# ❌ WRONG - Credentials in activity input (leaks to workflow history)
 @activity.defn(name="send_governance_event")
 async def send_governance_event(input: Dict[str, Any]):
+    # ❌ input["api_key"] is persisted in workflow history — readable by
+    # anyone with Describe access to the namespace.
     async with httpx.AsyncClient() as client:
-        response = await client.post(...)
+        response = await client.post(
+            input["api_url"],
+            headers={"Authorization": f"Bearer {input['api_key']}"},
+            json=input["payload"],
+        )
     return response.json()
 ```
 

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -328,30 +328,48 @@ def create_openbox_worker(
 ### 11. Governance Event Activity (`activities.py`)
 
 **Purpose:** Execute HTTP calls to OpenBox Core from workflow context
-**Activity:** `send_governance_event`
+**Activity:** `send_governance_event` (method of `GovernanceActivities` class)
 
-**Function Signature:**
+**Class Signature:**
 ```python
-@activity.defn(name="send_governance_event")
-async def send_governance_event(input: Dict[str, Any]) -> Optional[Dict[str, Any]]
+class GovernanceActivities:
+    def __init__(self, api_url: str, api_key: str): ...
+
+    @activity.defn(name="send_governance_event")
+    async def send_governance_event(
+        self, input: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]: ...
+
+
+def build_governance_activities(api_url: str, api_key: str) -> GovernanceActivities
 ```
 
-**Input Fields:**
-- `api_url` - OpenBox Core URL
-- `api_key` - Bearer token
+The plugin / `create_openbox_worker()` factory build one instance and register
+its bound `send_governance_event` method with the Temporal Worker.
+Credentials live on `self` — they do **not** flow through activity inputs,
+so the API key is never written to workflow history.
+
+**Input Fields (activity input dict):**
 - `payload` - Event data (without timestamp)
 - `timeout` - Request timeout
 - `on_api_error` - "fail_open" or "fail_closed"
 
+> `api_url` / `api_key` are deliberately absent from the input dict to avoid
+> leaking credentials into workflow history. They are held on the activity
+> instance itself.
+
 **Behavior:**
 - Adds RFC3339 timestamp to payload
-- POSTs to `/api/v1/governance/evaluate`
+- POSTs to `{self._api_url}/api/v1/governance/evaluate`
 - Parses verdict from response
 - For SignalReceived: Returns verdict dict (workflow interceptor stores it)
 - For other events with BLOCK/HALT: Raises non-retryable `ApplicationError`
+  with `type="GovernanceBlock"` / `"GovernanceHalt"`
 - On API failure with fail_closed: Raises `GovernanceAPIError`
 
-**Lines of Code:** 163
+A module-level `send_governance_event(input)` helper remains for direct
+callers (tests, scripts) that already hold credentials; it instantiates
+`GovernanceActivities` internally and delegates.
 
 ---
 

--- a/openbox/__init__.py
+++ b/openbox/__init__.py
@@ -68,7 +68,7 @@ from .span_processor import WorkflowSpanProcessor
 from .workflow_interceptor import GovernanceInterceptor
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# Plugin (requires temporalio >= 1.24.0)
+# Plugin (requires temporalio >= 1.23.0)
 # ═══════════════════════════════════════════════════════════════════════════════
 
 try:
@@ -76,7 +76,7 @@ try:
 
     from .plugin import OpenBoxPlugin
 except ImportError:
-    pass  # temporalio < 1.24.0, plugin not available
+    pass  # temporalio < 1.23.0, plugin not available
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Verdict Handler
@@ -139,7 +139,7 @@ from .client import GovernanceClient
 __all__ = [
     # Simple Worker Factory (recommended)
     "create_openbox_worker",
-    # Plugin (recommended for temporalio >= 1.24.0)
+    # Plugin (recommended for temporalio >= 1.23.0)
     "OpenBoxPlugin",
     # Configuration
     "initialize",

--- a/openbox/activities.py
+++ b/openbox/activities.py
@@ -142,60 +142,109 @@ def _handle_api_error(event_type: str, error_msg: str, on_api_error: str) -> dic
     return {"success": False, "error": error_msg}
 
 
-@activity.defn(name="send_governance_event")
+class GovernanceActivities:
+    """Container for Temporal activities that need OpenBox credentials.
+
+    Credentials live on the instance (never in activity inputs → never in
+    workflow history → not visible to anyone with namespace read access).
+    The worker registers bound methods of a single instance, created at
+    worker-init time by the plugin / create_openbox_worker factory.
+    """
+
+    def __init__(self, api_url: str, api_key: str):
+        self._api_url = api_url.rstrip("/")
+        self._api_key = api_key
+
+    @activity.defn(name="send_governance_event")
+    async def send_governance_event(
+        self, input: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """Send a governance event to OpenBox Core.
+
+        Called from WorkflowInboundInterceptor via workflow.execute_activity()
+        to maintain workflow determinism. The `input` dict carries only the
+        event payload and per-call policy — never credentials.
+        """
+        event_payload = input.get("payload", {})
+        timeout = input.get("timeout", 30.0)
+        on_api_error = input.get("on_api_error", "fail_open")
+
+        # Add timestamp in activity context (non-deterministic code allowed)
+        payload = {**event_payload, "timestamp": _rfc3339_now()}
+        event_type = event_payload.get("event_type", "unknown")
+
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                response = await client.post(
+                    f"{self._api_url}/api/v1/governance/evaluate",
+                    json=payload,
+                    headers=build_auth_headers(self._api_key),
+                )
+
+                if response.status_code != 200:
+                    return _handle_api_error(
+                        event_type,
+                        f"HTTP {response.status_code}: {response.text}",
+                        on_api_error,
+                    )
+
+                data = response.json()
+                verdict = Verdict.from_string(
+                    data.get("verdict") or data.get("action", "continue")
+                )
+                reason = data.get("reason")
+                policy_id = data.get("policy_id")
+                risk_score = data.get("risk_score", 0.0)
+
+                if verdict.should_stop():
+                    result = await _handle_stop_verdict(
+                        verdict,
+                        reason,
+                        policy_id,
+                        risk_score,
+                        event_type,
+                        event_payload,
+                    )
+                    if result:
+                        return result
+
+                return _build_verdict_result(verdict, reason, policy_id, risk_score)
+
+        except (GovernanceAPIError, ApplicationError):
+            raise
+        except Exception as e:
+            logger.warning(f"Failed to send {event_type} event: {e}")
+            if on_api_error == "fail_closed":
+                raise GovernanceAPIError(str(e))
+            return {"success": False, "error": str(e)}
+
+
+def build_governance_activities(
+    api_url: str, api_key: str
+) -> GovernanceActivities:
+    """Factory used by plugin.py and worker.py to build the activities instance."""
+    return GovernanceActivities(api_url=api_url, api_key=api_key)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Backward-compat module-level helper.
+#
+# Not decorated with @activity.defn — worker/plugin register the class-based
+# version above so credentials never flow through activity inputs. This shim
+# exists for direct callers (tests, scripts) who already hold credentials and
+# want to invoke the HTTP logic without constructing the class themselves.
+# ─────────────────────────────────────────────────────────────────────────────
 async def send_governance_event(input: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Backward-compat wrapper — delegates to GovernanceActivities.
+
+    Tests and direct callers can keep passing api_url/api_key in the input
+    dict. The class-based activity registered with the worker does NOT see
+    these fields (it reads credentials from self), so nothing written to
+    workflow history ever carries the API key.
     """
-    Activity that sends governance events to OpenBox Core.
-
-    Called from WorkflowInboundInterceptor via workflow.execute_activity()
-    to maintain workflow determinism.
-    """
-    api_url = input.get("api_url", "")
-    api_key = input.get("api_key", "")
-    event_payload = input.get("payload", {})
-    timeout = input.get("timeout", 30.0)
-    on_api_error = input.get("on_api_error", "fail_open")
-
-    # Add timestamp in activity context (non-deterministic code allowed)
-    payload = {**event_payload, "timestamp": _rfc3339_now()}
-    event_type = event_payload.get("event_type", "unknown")
-
-    try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            response = await client.post(
-                f"{api_url}/api/v1/governance/evaluate",
-                json=payload,
-                headers=build_auth_headers(api_key),
-            )
-
-            if response.status_code != 200:
-                return _handle_api_error(
-                    event_type,
-                    f"HTTP {response.status_code}: {response.text}",
-                    on_api_error,
-                )
-
-            data = response.json()
-            verdict = Verdict.from_string(
-                data.get("verdict") or data.get("action", "continue")
-            )
-            reason = data.get("reason")
-            policy_id = data.get("policy_id")
-            risk_score = data.get("risk_score", 0.0)
-
-            if verdict.should_stop():
-                result = await _handle_stop_verdict(
-                    verdict, reason, policy_id, risk_score, event_type, event_payload
-                )
-                if result:
-                    return result
-
-            return _build_verdict_result(verdict, reason, policy_id, risk_score)
-
-    except (GovernanceAPIError, ApplicationError):
-        raise
-    except Exception as e:
-        logger.warning(f"Failed to send {event_type} event: {e}")
-        if on_api_error == "fail_closed":
-            raise GovernanceAPIError(str(e))
-        return {"success": False, "error": str(e)}
+    instance = GovernanceActivities(
+        api_url=input.get("api_url", ""),
+        api_key=input.get("api_key", ""),
+    )
+    forwarded = {k: v for k, v in input.items() if k not in ("api_url", "api_key")}
+    return await instance.send_governance_event(forwarded)

--- a/openbox/errors.py
+++ b/openbox/errors.py
@@ -21,10 +21,24 @@ Hierarchy:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Final, Union
 
 if TYPE_CHECKING:
     from .types import Verdict
+
+
+# ═══════════════════════════════════════════════════════════════════
+# ApplicationError.type values raised by governance activities.
+# Use these constants — never string-match on error messages or
+# exception class names (brittle against locale / reformatting /
+# Temporal's ActivityError wrapping).
+# ═══════════════════════════════════════════════════════════════════
+
+GOVERNANCE_HALT_ERROR_TYPE: Final[str] = "GovernanceHalt"
+GOVERNANCE_BLOCK_ERROR_TYPE: Final[str] = "GovernanceBlock"
+GOVERNANCE_API_ERROR_TYPE: Final[str] = "GovernanceAPIError"
+# Legacy alias; kept for histories predating the rename.
+GOVERNANCE_STOP_ERROR_TYPE: Final[str] = "GovernanceStop"
 
 
 # ═══════════════════════════════════════════════════════════════════

--- a/openbox/hook_governance.py
+++ b/openbox/hook_governance.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import httpx
@@ -38,9 +39,14 @@ _max_body_size: Optional[int] = None
 _span_processor: Optional["WorkflowSpanProcessor"] = None
 _cached_auth_headers: Optional[dict] = None
 
-# Persistent HTTP clients (lazy-init, thread-safe for requests)
+# Persistent HTTP clients. httpx Client/AsyncClient themselves are thread-safe
+# for requests; the locks below only guard creation against concurrent activities
+# racing to initialize a fresh client (which would leak connection pools when
+# one of the losers gets garbage collected).
 _sync_client: Optional[httpx.Client] = None
 _async_client: Optional[httpx.AsyncClient] = None
+_sync_client_lock = threading.Lock()
+_async_client_lock = threading.Lock()
 
 
 def configure(
@@ -78,18 +84,22 @@ def configure(
 
 
 def _get_sync_client() -> httpx.Client:
-    """Get or create persistent sync HTTP client."""
+    """Get or create persistent sync HTTP client (double-checked locking)."""
     global _sync_client
     if _sync_client is None or _sync_client.is_closed:
-        _sync_client = httpx.Client(timeout=_api_timeout)
+        with _sync_client_lock:
+            if _sync_client is None or _sync_client.is_closed:
+                _sync_client = httpx.Client(timeout=_api_timeout)
     return _sync_client
 
 
 def _get_async_client() -> httpx.AsyncClient:
-    """Get or create persistent async HTTP client."""
+    """Get or create persistent async HTTP client (double-checked locking)."""
     global _async_client
     if _async_client is None or _async_client.is_closed:
-        _async_client = httpx.AsyncClient(timeout=_api_timeout)
+        with _async_client_lock:
+            if _async_client is None or _async_client.is_closed:
+                _async_client = httpx.AsyncClient(timeout=_api_timeout)
     return _async_client
 
 

--- a/openbox/plugin.py
+++ b/openbox/plugin.py
@@ -17,6 +17,7 @@ Usage:
 """
 
 import dataclasses
+import logging
 from typing import Any, Optional, Set
 
 from temporalio.plugin import SimplePlugin
@@ -26,6 +27,8 @@ from temporalio.worker.workflow_sandbox import SandboxedWorkflowRunner
 from .config import initialize as validate_api_key, GovernanceConfig
 from .span_processor import WorkflowSpanProcessor
 from .client import GovernanceClient
+
+logger = logging.getLogger(__name__)
 
 
 class OpenBoxPlugin(SimplePlugin):
@@ -62,6 +65,11 @@ class OpenBoxPlugin(SimplePlugin):
         db_libraries: Optional[Set[str]] = None,
         sqlalchemy_engine: Optional[Any] = None,
         instrument_file_io: bool = True,
+        # Propagate W3C traceparent/baggage through Temporal headers so spans
+        # started by the caller (e.g., an HTTP server) stitch to workflow and
+        # activity spans on the worker side. Uses Temporal's built-in
+        # TracingInterceptor under the hood.
+        enable_trace_propagation: bool = True,
     ):
         # 1. Validate API key (sync, uses urllib)
         validate_api_key(
@@ -115,7 +123,7 @@ class OpenBoxPlugin(SimplePlugin):
             on_api_error=governance_policy,
         )
 
-        interceptors = [
+        interceptors: list = [
             GovernanceInterceptor(
                 api_url=openbox_url,
                 api_key=openbox_api_key,
@@ -131,8 +139,23 @@ class OpenBoxPlugin(SimplePlugin):
             ),
         ]
 
-        # 6. Get governance activity
-        from .activities import send_governance_event
+        # Header-based OTel trace propagation. Temporal's built-in
+        # TracingInterceptor implements both client.Interceptor and
+        # worker.Interceptor — SimplePlugin auto-routes it to both sides.
+        # Without it, trace IDs set by the caller don't reach workflow/
+        # activity spans, leaving disconnected trees in the backend.
+        if enable_trace_propagation:
+            from temporalio.contrib.opentelemetry import TracingInterceptor
+
+            interceptors.append(TracingInterceptor())
+
+        # 6. Build governance activity instance with credentials captured in self —
+        # avoids passing api_key through activity inputs / workflow history.
+        from .activities import build_governance_activities
+
+        governance_activities = build_governance_activities(
+            api_url=openbox_url, api_key=openbox_api_key
+        )
 
         # 7. Sandbox passthrough for opentelemetry
         def workflow_runner(runner: WorkflowRunner | None) -> WorkflowRunner | None:
@@ -157,7 +180,7 @@ class OpenBoxPlugin(SimplePlugin):
         super().__init__(
             "openbox.OpenBoxPlugin",
             interceptors=interceptors,
-            activities=[send_governance_event],
+            activities=[governance_activities.send_governance_event],
             workflow_runner=workflow_runner,
         )
 
@@ -171,15 +194,17 @@ class OpenBoxPlugin(SimplePlugin):
 
         config = super().configure_worker(config)
 
-        print("OpenBox Plugin initialized successfully")
-        print(f"  - Governance policy: {self._governance_policy}")
-        print(f"  - Governance timeout: {self._governance_timeout}s")
         db_status = "enabled" if self._instrument_databases else "disabled"
         file_status = "enabled" if self._instrument_file_io else "disabled"
         hitl_status = "enabled" if self._hitl_enabled else "disabled"
-        print(f"  - Database instrumentation: {db_status}")
-        print(f"  - File I/O instrumentation: {file_status}")
-        print(f"  - Approval polling: {hitl_status}")
-        print("  - Hook governance: enabled")
+        logger.info(
+            "OpenBox Plugin initialized: policy=%s timeout=%ss "
+            "db=%s file=%s hitl=%s hook_governance=enabled",
+            self._governance_policy,
+            self._governance_timeout,
+            db_status,
+            file_status,
+            hitl_status,
+        )
 
         return config

--- a/openbox/worker.py
+++ b/openbox/worker.py
@@ -18,6 +18,7 @@ Usage:
     await worker.run()
 """
 
+import logging
 from datetime import timedelta
 from typing import (
     Any,
@@ -35,6 +36,8 @@ from temporalio.worker import Worker, Interceptor
 
 from .config import initialize as validate_api_key, GovernanceConfig
 from .span_processor import WorkflowSpanProcessor
+
+logger = logging.getLogger(__name__)
 
 
 def create_openbox_worker(
@@ -61,6 +64,9 @@ def create_openbox_worker(
     sqlalchemy_engine: Optional[Any] = None,
     # File I/O instrumentation
     instrument_file_io: bool = True,
+    # Header-based W3C trace propagation via Temporal's built-in TracingInterceptor.
+    # Without it, trace IDs set by the caller don't reach workflow/activity spans.
+    enable_trace_propagation: bool = True,
     # Standard Worker options
     activity_executor: Optional[Executor] = None,
     workflow_task_executor: Optional[ThreadPoolExecutor] = None,
@@ -156,8 +162,7 @@ def create_openbox_worker(
         await worker.run()
         ```
     """
-    # Initialize OpenBox
-    print(f"Initializing OpenBox SDK with URL: {openbox_url}")
+    logger.info("Initializing OpenBox SDK with URL: %s", openbox_url)
 
     # 0. Store Temporal client reference for HALT terminate calls
     from .activities import set_temporal_client
@@ -231,27 +236,35 @@ def create_openbox_worker(
         client=governance_client,
     )
 
-    # 6. Get governance activities
-    from .activities import send_governance_event
+    # 6. Build governance activities with credentials captured on the instance
+    # (so api_key never leaks through activity inputs into workflow history).
+    from .activities import build_governance_activities
+
+    governance_activities = build_governance_activities(
+        api_url=openbox_url, api_key=openbox_api_key
+    )
 
     # Add OpenBox components
-    all_interceptors = [workflow_interceptor, activity_interceptor, *interceptors]
-    all_activities = [*activities, send_governance_event]
+    all_interceptors: list = [workflow_interceptor, activity_interceptor, *interceptors]
 
-    print("OpenBox SDK initialized successfully")
-    print(f"  - Governance policy: {governance_policy}")
-    print(f"  - Governance timeout: {governance_timeout}s")
-    print(
-        "  - Events: WorkflowStarted, WorkflowCompleted, WorkflowFailed, SignalReceived, ActivityStarted, ActivityCompleted"
+    # Header-based OTel trace propagation via Temporal's built-in interceptor.
+    if enable_trace_propagation:
+        from temporalio.contrib.opentelemetry import TracingInterceptor
+
+        all_interceptors.append(TracingInterceptor())
+
+    all_activities = [*activities, governance_activities.send_governance_event]
+
+    logger.info(
+        "OpenBox SDK initialized: policy=%s timeout=%ss db=%s file=%s hitl=%s "
+        "hook_governance=enabled events=WorkflowStarted,WorkflowCompleted,"
+        "WorkflowFailed,SignalReceived,ActivityStarted,ActivityCompleted",
+        governance_policy,
+        governance_timeout,
+        "enabled" if instrument_databases else "disabled",
+        "enabled" if instrument_file_io else "disabled",
+        "enabled" if hitl_enabled else "disabled",
     )
-    print(
-        f"  - Database instrumentation: {'enabled' if instrument_databases else 'disabled'}"
-    )
-    print(
-        f"  - File I/O instrumentation: {'enabled' if instrument_file_io else 'disabled'}"
-    )
-    print(f"  - Approval polling: {'enabled' if hitl_enabled else 'disabled'}")
-    print("  - Hook governance: enabled")
 
     # Create and return Worker
     return Worker(

--- a/openbox/workflow_interceptor.py
+++ b/openbox/workflow_interceptor.py
@@ -20,6 +20,7 @@ from datetime import timedelta
 from typing import Any, Optional, Type
 
 from temporalio import workflow
+from temporalio.exceptions import ActivityError, ApplicationError
 from temporalio.worker import (
     Interceptor,
     WorkflowInboundInterceptor,
@@ -28,7 +29,36 @@ from temporalio.worker import (
     HandleSignalInput,
 )
 
+from .errors import (
+    GOVERNANCE_API_ERROR_TYPE,
+    GOVERNANCE_BLOCK_ERROR_TYPE,
+    GOVERNANCE_HALT_ERROR_TYPE,
+    GOVERNANCE_STOP_ERROR_TYPE,
+)
 from .types import Verdict
+
+
+def _application_error_type(exc: BaseException) -> Optional[str]:
+    """Walk exception chain and return the ApplicationError.type if present.
+
+    Temporal wraps activity failures as ActivityError(cause=ApplicationError).
+    We walk cause/__cause__/__context__ to find the first ApplicationError and
+    return its `type` field. Matching on this field is stable across message
+    reformatting, locale changes, and nested wrapping.
+    """
+    seen: set[int] = set()
+    current: Optional[BaseException] = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, ApplicationError):
+            return getattr(current, "type", None)
+        next_exc = (
+            getattr(current, "cause", None)
+            or getattr(current, "__cause__", None)
+            or getattr(current, "__context__", None)
+        )
+        current = next_exc
+    return None
 
 
 def _safe_error_type(exc) -> Optional[str]:
@@ -117,8 +147,6 @@ from .errors import GovernanceHaltError  # noqa: F401
 
 
 async def _send_governance_event(
-    api_url: str,
-    api_key: str,
     payload: dict,
     timeout: float,
     on_api_error: str = "fail_open",
@@ -130,17 +158,18 @@ async def _send_governance_event(
         on_api_error: "fail_open" (default) = continue on error
                       "fail_closed" = halt workflow if governance API fails
 
-    The on_api_error policy is passed to the activity, which handles logging
-    (safe outside sandbox) and raises GovernanceAPIError if fail_closed.
-    This interceptor catches that and re-raises as GovernanceHaltError.
+    Credentials (api_url, api_key) are held by the activity instance itself —
+    never passed through activity inputs, so they never land in workflow
+    history. The on_api_error policy is passed to the activity, which handles
+    logging (safe outside sandbox) and raises GovernanceAPIError if
+    fail_closed. This interceptor catches that and re-raises as
+    GovernanceHaltError.
     """
     try:
         result = await workflow.execute_activity(
             "send_governance_event",
             args=[
                 {
-                    "api_url": api_url,
-                    "api_key": api_key,
                     "payload": payload,
                     "timeout": timeout,
                     "on_api_error": on_api_error,
@@ -150,27 +179,26 @@ async def _send_governance_event(
         )
         return result
     except Exception as e:
-        error_str = str(e)
-        error_type = type(e).__name__
+        app_error_type = _application_error_type(e)
 
-        # GovernanceHalt: workflow should terminate (client.terminate() already called,
-        # but re-raise to ensure workflow code path stops)
-        if "GovernanceHalt" in error_str:
-            raise GovernanceHaltError(error_str)
+        # GovernanceHalt / legacy GovernanceStop: workflow should terminate
+        # (client.terminate() already called by the activity, but re-raise to
+        # ensure the workflow code path stops).
+        if app_error_type in (
+            GOVERNANCE_HALT_ERROR_TYPE,
+            GOVERNANCE_STOP_ERROR_TYPE,
+        ):
+            raise GovernanceHaltError(str(e))
 
-        # GovernanceBlock: activity blocked, workflow continues
-        if "GovernanceBlock" in error_str:
+        # GovernanceBlock: the current activity is blocked; the workflow continues.
+        if app_error_type == GOVERNANCE_BLOCK_ERROR_TYPE:
             return None
 
-        # Legacy GovernanceStop (backward compat) → treat as halt
-        if "GovernanceStop" in error_str:
-            raise GovernanceHaltError(error_str)
+        # Activity raised GovernanceAPIError (fail_closed + API unreachable).
+        if app_error_type == GOVERNANCE_API_ERROR_TYPE:
+            raise GovernanceHaltError(str(e))
 
-        # Activity raised GovernanceAPIError (fail_closed and API unreachable)
-        if "GovernanceAPIError" in error_type or "GovernanceAPIError" in error_str:
-            raise GovernanceHaltError(error_str)
-
-        # Other errors with fail_open: silently continue
+        # Other errors with fail_open: silently continue.
         return None
 
 
@@ -179,12 +207,15 @@ class GovernanceInterceptor(Interceptor):
 
     def __init__(
         self,
-        api_url: str,
-        api_key: str,
+        api_url: str = "",
+        api_key: str = "",
         span_processor=None,  # Shared with activity interceptor for HTTP spans
         config=None,  # Optional GovernanceConfig
     ):
-        self.api_url = api_url.rstrip("/")
+        # api_url / api_key are accepted for backward compatibility but no longer
+        # flow to the governance activity — credentials live on GovernanceActivities.
+        # Kept on self in case downstream callers introspect.
+        self.api_url = api_url.rstrip("/") if api_url else ""
         self.api_key = api_key
         self.span_processor = span_processor
         self.api_timeout = getattr(config, "api_timeout", 30.0) if config else 30.0
@@ -203,8 +234,6 @@ class GovernanceInterceptor(Interceptor):
         self, input: WorkflowInterceptorClassInput
     ) -> Optional[Type[WorkflowInboundInterceptor]]:
         # Capture via closure
-        api_url = self.api_url
-        api_key = self.api_key
         span_processor = self.span_processor
         timeout = self.api_timeout
         on_error = self.on_api_error
@@ -223,8 +252,6 @@ class GovernanceInterceptor(Interceptor):
                 # WorkflowStarted event
                 if send_start and workflow.patched("openbox-v2-start"):
                     await _send_governance_event(
-                        api_url,
-                        api_key,
                         {
                             "source": "workflow-telemetry",
                             "event_type": "WorkflowStarted",
@@ -254,8 +281,6 @@ class GovernanceInterceptor(Interceptor):
                             )
 
                         await _send_governance_event(
-                            api_url,
-                            api_key,
                             {
                                 "source": "workflow-telemetry",
                                 "event_type": "WorkflowCompleted",
@@ -273,20 +298,24 @@ class GovernanceInterceptor(Interceptor):
                     error = _build_error_dict(e)
 
                     if workflow.patched("openbox-v2-failed"):
-                        await _send_governance_event(
-                            api_url,
-                            api_key,
-                            {
-                                "source": "workflow-telemetry",
-                                "event_type": "WorkflowFailed",
-                                "workflow_id": info.workflow_id,
-                                "run_id": info.run_id,
-                                "workflow_type": info.workflow_type,
-                                "error": error,
-                            },
-                            timeout,
-                            on_error,
-                        )
+                        # Swallow failures from the failure-reporting activity itself
+                        # (fail_closed + governance API down would otherwise raise
+                        # GovernanceHaltError and shadow the real workflow exception).
+                        try:
+                            await _send_governance_event(
+                                {
+                                    "source": "workflow-telemetry",
+                                    "event_type": "WorkflowFailed",
+                                    "workflow_id": info.workflow_id,
+                                    "run_id": info.run_id,
+                                    "workflow_type": info.workflow_type,
+                                    "error": error,
+                                },
+                                timeout,
+                                on_error,
+                            )
+                        except Exception:
+                            pass
 
                     raise
 
@@ -300,8 +329,6 @@ class GovernanceInterceptor(Interceptor):
                 # SignalReceived event - check verdict and store if "stop"
                 if workflow.patched("openbox-v2-signal"):
                     result = await _send_governance_event(
-                        api_url,
-                        api_key,
                         {
                             "source": "workflow-telemetry",
                             "event_type": "SignalReceived",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openbox-temporal-sdk-python"
-version = "1.1.1"
+version = "1.1.2"
 description = "OpenBox SDK - Governance and observability for Temporal workflows"
 authors = [
     { name = "OpenBox Team", email = "tino@openbox.ai" },

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -23,6 +23,9 @@ def _make_plugin(**overrides):
     defaults = dict(
         openbox_url="http://localhost:8086",
         openbox_api_key="obx_test_key_123",
+        # Skip the real TracingInterceptor by default — many tests pass Mock
+        # clients that SimplePlugin's interceptor-dedup logic can't iterate.
+        enable_trace_propagation=False,
     )
     defaults.update(overrides)
 

--- a/tests/test_plugin_integration.py
+++ b/tests/test_plugin_integration.py
@@ -243,10 +243,11 @@ class TestPluginReplaySafety:
             await handle.result()
             history = await handle.fetch_history()
 
-        # Replay — governance activity calls are recorded in history,
-        # so replay just validates determinism without executing them again.
+        # Replay with the plugin wired in — this validates that the plugin's
+        # interceptors themselves are replay-safe, not just the workflow code.
         replayer = Replayer(
             workflows=[SimpleWorkflow],
+            plugins=[plugin],
         )
         # This will raise if there's a non-determinism error
         await replayer.replay_workflow(history)
@@ -276,5 +277,5 @@ class TestPluginReplaySafety:
             await handle.result()
             history = await handle.fetch_history()
 
-        replayer = Replayer(workflows=[SignalWorkflow])
+        replayer = Replayer(workflows=[SignalWorkflow], plugins=[plugin])
         await replayer.replay_workflow(history)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -286,10 +286,10 @@ class TestCreateOpenboxWorkerWithConfig:
     @patch("openbox.otel_setup.setup_opentelemetry_for_governance")
     @patch("openbox.workflow_interceptor.GovernanceInterceptor")
     @patch("openbox.activity_interceptor.ActivityGovernanceInterceptor")
-    @patch("openbox.activities.send_governance_event")
+    @patch("openbox.activities.build_governance_activities")
     def test_adds_send_governance_event_to_activities(
         self,
-        mock_send_governance_event,
+        mock_build_activities,
         mock_activity_interceptor,
         mock_governance_interceptor,
         mock_setup_otel,
@@ -298,8 +298,11 @@ class TestCreateOpenboxWorkerWithConfig:
         mock_validate_api_key,
         mock_worker_class,
     ):
-        """Test adds send_governance_event to activities."""
+        """The class-based send_governance_event method is registered on the worker."""
         from openbox.worker import create_openbox_worker
+
+        sentinel_method = Mock(name="send_governance_event_method")
+        mock_build_activities.return_value.send_governance_event = sentinel_method
 
         mock_client = Mock()
 
@@ -312,13 +315,17 @@ class TestCreateOpenboxWorkerWithConfig:
             activities=[my_activity],
             openbox_url="http://localhost:8086",
             openbox_api_key="obx_test_key123",
+            enable_trace_propagation=False,
         )
 
-        # Verify Worker was called with send_governance_event in activities
         mock_worker_class.assert_called_once()
         call_kwargs = mock_worker_class.call_args[1]
         assert my_activity in call_kwargs["activities"]
-        assert mock_send_governance_event in call_kwargs["activities"]
+        assert sentinel_method in call_kwargs["activities"]
+        # Credentials must be captured on the activity instance, not flowed via input
+        mock_build_activities.assert_called_once_with(
+            api_url="http://localhost:8086", api_key="obx_test_key123"
+        )
 
     @patch("openbox.worker.Worker")
     @patch("openbox.worker.validate_api_key")
@@ -740,6 +747,7 @@ class TestParameterPassthrough:
             interceptors=[mock_custom_interceptor_1, mock_custom_interceptor_2],
             openbox_url="http://localhost:8086",
             openbox_api_key="obx_test_key123",
+            enable_trace_propagation=False,
         )
 
         mock_worker_class.assert_called_once()
@@ -795,10 +803,12 @@ class TestParameterPassthrough:
         call_kwargs = mock_worker_class.call_args[1]
         activities = call_kwargs["activities"]
 
-        # Custom activities should be first, then send_governance_event
+        # Custom activities should be first, then the class-based governance method.
         assert activity_a in activities
         assert activity_b in activities
-        assert mock_send_governance_event in activities
+        assert any(
+            getattr(a, "__name__", "") == "send_governance_event" for a in activities
+        )
 
 
 # ===============================================================================
@@ -1490,33 +1500,38 @@ class TestPrintOutput:
         mock_validate_api_key,
         mock_worker_class,
         mock_print,
+        caplog,
     ):
-        """Test prints initialization messages when OpenBox is configured."""
+        """Initialization status is logged via the module logger (not print())."""
+        import logging
         from openbox.worker import create_openbox_worker
 
         mock_client = Mock()
 
-        create_openbox_worker(
-            client=mock_client,
-            task_queue="test-queue",
-            openbox_url="http://localhost:8086",
-            openbox_api_key="obx_test_key123",
-            governance_policy="fail_closed",
-            governance_timeout=45.0,
-            instrument_databases=True,
-            instrument_file_io=True,
-            hitl_enabled=True,
-        )
+        with caplog.at_level(logging.INFO, logger="openbox.worker"):
+            create_openbox_worker(
+                client=mock_client,
+                task_queue="test-queue",
+                openbox_url="http://localhost:8086",
+                openbox_api_key="obx_test_key123",
+                governance_policy="fail_closed",
+                governance_timeout=45.0,
+                instrument_databases=True,
+                instrument_file_io=True,
+                hitl_enabled=True,
+                enable_trace_propagation=False,
+            )
 
-        # Verify print calls
-        print_calls = [call[0][0] for call in mock_print.call_args_list]
-        assert "Initializing OpenBox SDK with URL: http://localhost:8086" in print_calls
-        assert "OpenBox SDK initialized successfully" in print_calls
-        assert "  - Governance policy: fail_closed" in print_calls
-        assert "  - Governance timeout: 45.0s" in print_calls
-        assert "  - Database instrumentation: enabled" in print_calls
-        assert "  - File I/O instrumentation: enabled" in print_calls
-        assert "  - Approval polling: enabled" in print_calls
+        # Must NOT use print() — library code should emit to logger
+        mock_print.assert_not_called()
+        log_text = "\n".join(record.getMessage() for record in caplog.records)
+        assert "Initializing OpenBox SDK with URL: http://localhost:8086" in log_text
+        assert "OpenBox SDK initialized" in log_text
+        assert "policy=fail_closed" in log_text
+        assert "timeout=45.0s" in log_text
+        assert "db=enabled" in log_text
+        assert "file=enabled" in log_text
+        assert "hitl=enabled" in log_text
 
     @patch("builtins.print")
     @patch("openbox.worker.Worker")
@@ -1538,27 +1553,31 @@ class TestPrintOutput:
         mock_validate_api_key,
         mock_worker_class,
         mock_print,
+        caplog,
     ):
-        """Test prints disabled status when features are turned off."""
+        """Disabled-status values surface in the logger output."""
+        import logging
         from openbox.worker import create_openbox_worker
 
         mock_client = Mock()
 
-        create_openbox_worker(
-            client=mock_client,
-            task_queue="test-queue",
-            openbox_url="http://localhost:8086",
-            openbox_api_key="obx_test_key123",
-            instrument_databases=False,
-            instrument_file_io=False,
-            hitl_enabled=False,
-        )
+        with caplog.at_level(logging.INFO, logger="openbox.worker"):
+            create_openbox_worker(
+                client=mock_client,
+                task_queue="test-queue",
+                openbox_url="http://localhost:8086",
+                openbox_api_key="obx_test_key123",
+                instrument_databases=False,
+                instrument_file_io=False,
+                hitl_enabled=False,
+                enable_trace_propagation=False,
+            )
 
-        # Verify print calls
-        print_calls = [call[0][0] for call in mock_print.call_args_list]
-        assert "  - Database instrumentation: disabled" in print_calls
-        assert "  - File I/O instrumentation: disabled" in print_calls
-        assert "  - Approval polling: disabled" in print_calls
+        mock_print.assert_not_called()
+        log_text = "\n".join(record.getMessage() for record in caplog.records)
+        assert "db=disabled" in log_text
+        assert "file=disabled" in log_text
+        assert "hitl=disabled" in log_text
 
 
 # ===============================================================================
@@ -1684,8 +1703,11 @@ class TestEdgeCases:
         mock_worker_class.assert_called_once()
         call_kwargs = mock_worker_class.call_args[1]
         assert call_kwargs["workflows"] == []
-        # activities will include send_governance_event
-        assert mock_send_governance_event in call_kwargs["activities"]
+        # Activities will include the class-based send_governance_event method.
+        assert any(
+            getattr(a, "__name__", "") == "send_governance_event"
+            for a in call_kwargs["activities"]
+        )
 
     @patch("openbox.worker.Worker")
     @patch("openbox.worker.validate_api_key")
@@ -1880,6 +1902,7 @@ class TestEdgeCases:
             interceptors=custom_interceptors,
             openbox_url="http://localhost:8086",
             openbox_api_key="obx_test_key123",
+            enable_trace_propagation=False,
         )
 
         mock_worker_class.assert_called_once()

--- a/tests/test_workflow_interceptor.py
+++ b/tests/test_workflow_interceptor.py
@@ -272,12 +272,10 @@ class TestSendGovernanceEvent:
 
     @pytest.mark.asyncio
     async def test_calls_execute_activity_with_correct_args(self, mock_workflow):
-        """Test that _send_governance_event calls workflow.execute_activity with correct args."""
+        """Activity input must carry payload/timeout/policy — never credentials."""
         mock_workflow.execute_activity = AsyncMock(return_value={"verdict": "allow"})
 
         result = await _send_governance_event(
-            api_url="https://api.openbox.ai",
-            api_key="test-key",
             payload={"event_type": "WorkflowStarted"},
             timeout=30.0,
             on_api_error="fail_open",
@@ -291,17 +289,17 @@ class TestSendGovernanceEvent:
 
         # Check args parameter contains expected data
         activity_input = call_args.kwargs["args"][0]
-        assert activity_input["api_url"] == "https://api.openbox.ai"
-        assert activity_input["api_key"] == "test-key"
         assert activity_input["payload"] == {"event_type": "WorkflowStarted"}
         assert activity_input["timeout"] == 30.0
         assert activity_input["on_api_error"] == "fail_open"
+        # Credentials must NOT be in the activity input (would leak via workflow history)
+        assert "api_url" not in activity_input
+        assert "api_key" not in activity_input
 
         assert result == {"verdict": "allow"}
 
     @pytest.mark.asyncio
     async def test_returns_result_on_success(self, mock_workflow):
-        """Test that _send_governance_event returns result on success."""
         expected_result = {
             "verdict": "allow",
             "reason": "Policy passed",
@@ -310,8 +308,6 @@ class TestSendGovernanceEvent:
         mock_workflow.execute_activity = AsyncMock(return_value=expected_result)
 
         result = await _send_governance_event(
-            api_url="https://api.openbox.ai",
-            api_key="test-key",
             payload={},
             timeout=30.0,
         )
@@ -322,78 +318,56 @@ class TestSendGovernanceEvent:
     async def test_raises_governance_halt_error_for_application_error(
         self, mock_workflow
     ):
-        """Test that ApplicationError with GovernanceHalt raises GovernanceHaltError."""
+        """ApplicationError.type == 'GovernanceHalt' must raise GovernanceHaltError."""
+        from temporalio.exceptions import ApplicationError
 
-        # Create a custom ApplicationError class to simulate the real one
-        class ApplicationError(Exception):
-            pass
-
-        error = ApplicationError("GovernanceHalt: Policy violation")
+        error = ApplicationError(
+            "Governance HALT: Policy violation", type="GovernanceHalt"
+        )
         mock_workflow.execute_activity = AsyncMock(side_effect=error)
 
         with pytest.raises(GovernanceHaltError) as exc_info:
             await _send_governance_event(
-                api_url="https://api.openbox.ai",
-                api_key="test-key",
                 payload={},
                 timeout=30.0,
             )
 
-        assert "GovernanceHalt" in str(exc_info.value)
+        assert "Policy violation" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_raises_governance_halt_error_for_governance_halt_message(
-        self, mock_workflow
-    ):
-        """Test that error with 'GovernanceHalt' in message raises GovernanceHaltError."""
-        error = Exception("GovernanceHalt: High risk detected")
+    async def test_legacy_governance_stop_type_raises_halt(self, mock_workflow):
+        """Legacy ApplicationError.type == 'GovernanceStop' still routes to halt."""
+        from temporalio.exceptions import ApplicationError
+
+        error = ApplicationError("legacy halt", type="GovernanceStop")
         mock_workflow.execute_activity = AsyncMock(side_effect=error)
 
-        with pytest.raises(GovernanceHaltError) as exc_info:
-            await _send_governance_event(
-                api_url="https://api.openbox.ai",
-                api_key="test-key",
-                payload={},
-                timeout=30.0,
-            )
-
-        assert "GovernanceHalt: High risk detected" in str(exc_info.value)
+        with pytest.raises(GovernanceHaltError):
+            await _send_governance_event(payload={}, timeout=30.0)
 
     @pytest.mark.asyncio
-    async def test_raises_governance_halt_error_for_governance_api_error(
-        self, mock_workflow
-    ):
-        """Test that GovernanceAPIError raises GovernanceHaltError."""
-        error = Exception("GovernanceAPIError: API unreachable")
+    async def test_governance_block_returns_none(self, mock_workflow):
+        """ApplicationError.type == 'GovernanceBlock' returns None (activity-level block)."""
+        from temporalio.exceptions import ApplicationError
+
+        error = ApplicationError("blocked", type="GovernanceBlock")
         mock_workflow.execute_activity = AsyncMock(side_effect=error)
 
-        with pytest.raises(GovernanceHaltError) as exc_info:
-            await _send_governance_event(
-                api_url="https://api.openbox.ai",
-                api_key="test-key",
-                payload={},
-                timeout=30.0,
-            )
-
-        assert "GovernanceAPIError" in str(exc_info.value)
+        result = await _send_governance_event(payload={}, timeout=30.0)
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_raises_governance_halt_error_for_governance_api_error_type(
         self, mock_workflow
     ):
-        """Test that exception with GovernanceAPIError in type name raises GovernanceHaltError."""
+        """ApplicationError.type == 'GovernanceAPIError' (fail_closed+API down) raises halt."""
+        from temporalio.exceptions import ApplicationError
 
-        # Create a custom GovernanceAPIError class to simulate the real one
-        class GovernanceAPIError(Exception):
-            pass
-
-        error = GovernanceAPIError("API failed")
+        error = ApplicationError("API failed", type="GovernanceAPIError")
         mock_workflow.execute_activity = AsyncMock(side_effect=error)
 
         with pytest.raises(GovernanceHaltError) as exc_info:
             await _send_governance_event(
-                api_url="https://api.openbox.ai",
-                api_key="test-key",
                 payload={},
                 timeout=30.0,
             )
@@ -401,14 +375,27 @@ class TestSendGovernanceEvent:
         assert "API failed" in str(exc_info.value)
 
     @pytest.mark.asyncio
+    async def test_string_matching_on_message_is_ignored(self, mock_workflow):
+        """Messages containing 'GovernanceHalt' must NOT trigger halt without proper type."""
+        # User workflow could legitimately throw an error whose string happens to contain
+        # "GovernanceHalt" — the old string-match logic would false-positive on this.
+        error = Exception("GovernanceHalt: user happens to mention this string")
+        mock_workflow.execute_activity = AsyncMock(side_effect=error)
+
+        result = await _send_governance_event(
+            payload={},
+            timeout=30.0,
+            on_api_error="fail_open",
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
     async def test_returns_none_for_other_errors_with_fail_open(self, mock_workflow):
-        """Test that other errors with fail_open return None."""
+        """Non-governance errors with fail_open return None."""
         error = RuntimeError("Network timeout")
         mock_workflow.execute_activity = AsyncMock(side_effect=error)
 
         result = await _send_governance_event(
-            api_url="https://api.openbox.ai",
-            api_key="test-key",
             payload={},
             timeout=30.0,
             on_api_error="fail_open",
@@ -418,13 +405,11 @@ class TestSendGovernanceEvent:
 
     @pytest.mark.asyncio
     async def test_default_on_api_error_is_fail_open(self, mock_workflow):
-        """Test that default on_api_error is fail_open."""
+        """Default on_api_error is fail_open."""
         error = RuntimeError("Some error")
         mock_workflow.execute_activity = AsyncMock(side_effect=error)
 
         result = await _send_governance_event(
-            api_url="https://api.openbox.ai",
-            api_key="test-key",
             payload={},
             timeout=30.0,
             # on_api_error not specified, should default to fail_open
@@ -434,14 +419,12 @@ class TestSendGovernanceEvent:
 
     @pytest.mark.asyncio
     async def test_timeout_is_passed_correctly(self, mock_workflow):
-        """Test that start_to_close_timeout is timeout + 5 seconds."""
+        """start_to_close_timeout is timeout + 5 seconds."""
         from datetime import timedelta
 
         mock_workflow.execute_activity = AsyncMock(return_value={})
 
         await _send_governance_event(
-            api_url="https://api.openbox.ai",
-            api_key="test-key",
             payload={},
             timeout=25.0,
         )
@@ -1257,12 +1240,14 @@ class TestInterceptorClosures:
             execute_input = MagicMock()
             await inbound.execute_workflow(execute_input)
 
-            # Verify the captured values were used
+            # Verify the captured values were used. Credentials are no longer
+            # passed through activity input (they live on the activity instance
+            # itself), so the activity input only carries payload/timeout/policy.
             calls = mock_workflow.execute_activity.call_args_list
             if calls:
                 activity_input = calls[0].kwargs["args"][0]
-                assert activity_input["api_url"] == "https://custom.api.url"
-                assert activity_input["api_key"] == "custom-api-key"
+                assert "api_url" not in activity_input
+                assert "api_key" not in activity_input
                 assert activity_input["timeout"] == 45.0
                 assert activity_input["on_api_error"] == "fail_closed"
 

--- a/uv.lock
+++ b/uv.lock
@@ -500,19 +500,19 @@ wheels = [
 
 [[package]]
 name = "nexus-rpc"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/f2/d54f5c03d8f4672ccc0875787a385f53dcb61f98a8ae594b5620e85b9cb3/nexus_rpc-1.3.0.tar.gz", hash = "sha256:e56d3b57b60d707ce7a72f83f23f106b86eca1043aa658e44582ab5ff30ab9ad", size = 75650, upload-time = "2025-12-08T22:59:13.002Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/d5/cd1ffb202b76ebc1b33c1332a3416e55a39929006982adc2b1eb069aaa9b/nexus_rpc-1.4.0.tar.gz", hash = "sha256:3b8b373d4865671789cc43623e3dc0bcbf192562e40e13727e17f1c149050fba", size = 82367, upload-time = "2026-02-25T22:01:34.053Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/74/0afd841de3199c148146c1d43b4bfb5605b2f1dc4c9a9087fe395091ea5a/nexus_rpc-1.3.0-py3-none-any.whl", hash = "sha256:aee0707b4861b22d8124ecb3f27d62dafbe8777dc50c66c91e49c006f971b92d", size = 28873, upload-time = "2025-12-08T22:59:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/11/52/6327a5f4fda01207205038a106a99848a41c83e933cd23ea2cab3d2ebc6c/nexus_rpc-1.4.0-py3-none-any.whl", hash = "sha256:14c953d3519113f8ccec533a9efdb6b10c28afef75d11cdd6d422640c40b3a49", size = 29645, upload-time = "2026-02-25T22:01:33.122Z" },
 ]
 
 [[package]]
 name = "openbox-temporal-sdk-python"
-version = "1.1.0"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
@@ -574,7 +574,7 @@ requires-dist = [
     { name = "pymysql", specifier = ">=1.0.0" },
     { name = "redis", specifier = ">=5.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
-    { name = "temporalio", specifier = ">=1.8.0,<2" },
+    { name = "temporalio", specifier = ">=1.23.0,<2" },
 ]
 
 [package.metadata.requires-dev]
@@ -1157,7 +1157,7 @@ wheels = [
 
 [[package]]
 name = "temporalio"
-version = "1.21.1"
+version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nexus-rpc" },
@@ -1165,13 +1165,13 @@ dependencies = [
     { name = "types-protobuf" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/9c/b4faa1f5ebb7cc7c264456012cbad083ea3f350abe6ea0921584ab46a51e/temporalio-1.21.1.tar.gz", hash = "sha256:9d4fbfd5d8cf1afdbf9e9c34f68158073904cee227eb602602ed86c39e992bd8", size = 1854258, upload-time = "2025-12-19T22:10:20.787Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/d4/fa21150a225393f87732ed6fef3cc9735d9e751edc6be415fe6e375105c6/temporalio-1.26.0.tar.gz", hash = "sha256:f4bfb35125e6f5e8c7f7ed1277c7354d812c6fac7ed5f8dbd50536cf289aaaa7", size = 2388994, upload-time = "2026-04-15T23:43:00.911Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/87/61b9e53cb5f71ca4474e30c8454be9c3622da7f72109b6d4de9b47490d4c/temporalio-1.21.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:476c575a8eb16ee0ebc388de42c8582465c5b2e01e6c662b23585b96afdda29e", size = 12034086, upload-time = "2025-12-19T22:10:00.615Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/ac/d7354048cc02de74cb11edf8d339c1579ffd9080c47782d0c1bf4d78df66/temporalio-1.21.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:1ba3980d6dff925aeff09d7de0bf82336a2c0159096801e9e755e0f01524a9a7", size = 11553488, upload-time = "2025-12-19T22:10:05.209Z" },
-    { url = "https://files.pythonhosted.org/packages/52/c2/7cabddc869ccd12cb9b9abdb94277eb401bcaa23185383d8861482b15ac2/temporalio-1.21.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38dd23396e7a8acad1419873d189e2ae49ae4357b1c2a005f19e94aaaf702f90", size = 11809946, upload-time = "2025-12-19T22:10:09.443Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/72/4f0b647c6b4b9467dbcd4d7aa69a714bdd63731c7cb6798daade8ad8786d/temporalio-1.21.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3f62aabb4df8855e40a1f66bd2b9d9226ebb4e2641377dceaf4eab4aaf708a6", size = 12144443, upload-time = "2025-12-19T22:10:14.387Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/b2/cf5402ab0b962d3f017190dcadebbbffa43f94b9513014aa39e790fc0a1e/temporalio-1.21.1-cp310-abi3-win_amd64.whl", hash = "sha256:a9bebb9f55f287b44fc88e9446e3abf1f91c7e6bff1842b40b04260ce6d9ce24", size = 12692499, upload-time = "2025-12-19T22:10:18.561Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/27/8c421c622d18cc8e034247d5d72b89e6456937344b5bec1de40abef3c085/temporalio-1.26.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:5489040c0cf621edeb36984199dd9e4fbd2b3a07d61a4f2a8da1f2cb9820ef26", size = 14221070, upload-time = "2026-04-15T23:42:26.21Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7c/d2b691d16ec5db87198c2e08dbfba58e286c096faee15753613a581abdce/temporalio-1.26.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:b18dd85771509c19ef059a31908bcd4e6130d1f67037c4db519702f3f2ad6d4a", size = 13583991, upload-time = "2026-04-15T23:42:34.357Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ca/b8728451320ca9d8bb6e1680b9bd23767118f86d5b8644edf2304d533f1b/temporalio-1.26.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46187d5f82ca2ae81f35ea5916a76db0e2f067210dc6b1852c3749475721946e", size = 13808036, upload-time = "2026-04-15T23:42:42.757Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/54/3113f5e0ac58655790abac64656373e06191b351d74bfb94692e81bd6784/temporalio-1.26.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:03300c3e5237443367ac61bb20bd726c656b3daa50310bdd436599d5bdc7cf97", size = 14336604, upload-time = "2026-04-15T23:42:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/9b/c50840a26af3587c0c8d9af04d9976743e22496996dc1a377efc75dcd316/temporalio-1.26.0-cp310-abi3-win_amd64.whl", hash = "sha256:1c4a0d82f0a3796cbf78864c799f8dca0b94cdaec68e7b8b224c859005686ec4", size = 14525849, upload-time = "2026-04-15T23:42:57.589Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Security**: `openbox_api_key` no longer flows through `send_governance_event` activity inputs and therefore is no longer written to workflow history. Credentials are captured on a new `GovernanceActivities` instance at worker init time. Anyone with Describe access on the Temporal namespace used to be able to read the key from the recorded activity input.
- **Observability**: W3C traceparent now propagates from the caller through Temporal workflow/activity headers via `temporalio.contrib.opentelemetry.TracingInterceptor`, wired automatically by `OpenBoxPlugin` and `create_openbox_worker`. Opt out with `enable_trace_propagation=False`.
- **Correctness**: Governance error routing inspects `ApplicationError.type` on the exception chain instead of substring-matching on `str(e)`. Eliminates false positives when a user workflow emits a message containing a governance keyword. Type strings exposed as `Final` constants in `errors.py`.
- **Correctness**: `WorkflowFailed` event send is wrapped in `try/except` so a `GovernanceHaltError` raised by the failure-reporting activity itself (`fail_closed` + API down) no longer shadows the real workflow exception.
- **Reliability**: Double-checked locking around the lazy `httpx` client in `hook_governance` — prevents two concurrent activities from each creating a client and leaking the loser's connection pool.
- **Test coverage**: Replayer in `test_plugin_integration.py` now receives the plugin so replay validates interceptor determinism, not just user workflow code.
- **Hygiene**: Module loggers replace `print()` in plugin/worker initialisation; `temporalio >= 1.23.0` version-pin comments corrected.
- Docs (README, codebase summary, code standards) updated for the class-based activity and the new `enable_trace_propagation` flag.

## Test plan

- [x] `uv run pytest` — 766 passing locally
- [x] Verify on CI
- [x] Smoke-test plugin integration against a real Temporal dev server (worker starts, workflow runs, governance event posts without `api_key` appearing in history)
- [x] Confirm upstream trace parent propagates to workflow spans end-to-end