### PR TITLE
PROD-189: Multi-agent session propagation + emit_handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 OpenBox SDK provides **governance and observability** for Temporal workflows by capturing workflow/activity lifecycle events, HTTP telemetry, database queries, and file operations, then sending them to OpenBox Core for policy evaluation.
 
 **Key Features:**
-- 6 event types (WorkflowStarted, WorkflowCompleted, WorkflowFailed, SignalReceived, ActivityStarted, ActivityCompleted)
+- 7 event types (WorkflowStarted, WorkflowCompleted, WorkflowFailed, SignalReceived, ActivityStarted, ActivityCompleted, Handoff)
+- Multi-agent sessions — propagate a shared `multi_agent_session_id` across workflow + activity events
 - 5-tier verdict system (ALLOW, CONSTRAIN, REQUIRE_APPROVAL, BLOCK, HALT)
 - **Hook-level governance** — per-operation evaluation (HTTP requests, file I/O, database queries, function tracing) with started/completed stages
 - HTTP/Database/File I/O instrumentation via OpenTelemetry
@@ -199,6 +200,48 @@ OpenBox Core returns a verdict indicating what action the SDK should take.
 | SignalReceived | Signal received | workflow_id, signal_name, signal_args |
 | ActivityStarted | Activity begins | activity_id, activity_type, activity_input |
 | ActivityCompleted | Activity ends | activity_id, activity_type, activity_input, activity_output, spans, status, duration |
+| Handoff | Agent hands off to another agent | from_agent_did, multi_agent_session_id |
+
+When a workflow runs as part of a multi-agent session (see below), every event
+above also carries `multi_agent_session_id`. The field is omitted when no
+session id is supplied.
+
+---
+
+## Multi-Agent Sessions
+
+Group the work of several agents under one shared `multi_agent_session_id`. The
+SDK only **propagates** the id you supply — it never invents one, and it owns no
+routing, session minting, or agent registry (those stay in your application).
+
+**Supply the id** via the Temporal workflow memo at start time:
+
+```python
+await client.start_workflow(
+    MyWorkflow.run,
+    arg,
+    id="order-123",
+    task_queue="my-queue",
+    memo={"openbox_multi_agent_session_id": session_id},
+)
+```
+
+The SDK then tags every governance event (workflow, activity, and hook events)
+with that id, propagating it from the workflow to its activities automatically.
+
+**Emit an explicit handoff** from inside workflow code:
+
+```python
+from openbox import emit_handoff
+
+await emit_handoff(
+    multi_agent_session_id=session_id,
+    from_agent_did="did:aip:...",   # the sending agent
+)
+```
+
+The receiving agent is derived server-side from the signed identity and is never
+sent. `emit_handoff` validates its arguments locally before any network call.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,6 +61,22 @@ OPENBOX_AGENT_PRIVATE_KEY=<base64 raw 32-byte Ed25519 seed>
 | `agent_name` | `str` | `None` | Agent name for governance context (optional) |
 | `tool_type_map` | `dict` | `{}` | Mapping of tool names to types for governance evaluation |
 
+## Multi-Agent Sessions
+
+No worker/plugin parameters. Your application supplies the shared
+`multi_agent_session_id` per workflow via the Temporal **workflow memo**; the SDK
+only propagates it. The SDK never invents a session id.
+
+| Mechanism | Key | Set by |
+|-----------|-----|--------|
+| Workflow memo | `openbox_multi_agent_session_id` | App, at `start_workflow(memo={...})` |
+
+When the memo is present, the id is attached to every workflow, activity, and
+hook governance event, and is propagated from the workflow to its activities
+internally. Emit an explicit handoff from workflow code with
+`emit_handoff(multi_agent_session_id=..., from_agent_did=...)`. See the README
+"Multi-Agent Sessions" section for usage.
+
 ## Instrumentation
 
 | Parameter | Type | Default | Description |

--- a/openbox/__init__.py
+++ b/openbox/__init__.py
@@ -57,6 +57,10 @@ from .types import (
     GuardrailsCheckResult,
 )
 
+# Multi-agent primitives (sandbox-safe — only imports temporalio.workflow eagerly;
+# signing/HTTP routed lazily through the governance activity).
+from .multi_agent import emit_handoff
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # Span Processor
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -169,6 +173,8 @@ __all__ = [
     "WorkflowSpanBuffer",
     "GovernanceVerdictResponse",
     "GuardrailsCheckResult",
+    # Multi-agent
+    "emit_handoff",
     # Span Processor
     "WorkflowSpanProcessor",
     # Interceptors

--- a/openbox/activity_interceptor.py
+++ b/openbox/activity_interceptor.py
@@ -86,6 +86,7 @@ from .types import (
     GovernanceBlockedError,
 )
 from .hook_governance import build_auth_headers
+from .multi_agent import read_session_from_header
 from .activities import _terminate_workflow_for_halt
 from .verdict_handler import enforce_verdict
 from .errors import GovernanceHaltError, GuardrailsValidationError
@@ -204,6 +205,13 @@ class _ActivityInterceptor(ActivityInboundInterceptor):
         if info.activity_type in self._config.skip_activity_types:
             return await self.next.execute_activity(input)
 
+        # Multi-agent session id from the header stamped by the workflow outbound
+        # interceptor. Request-local — never stored on self / a module global, since
+        # one worker serves many sessions concurrently.
+        session_id = read_session_from_header(
+            input.headers, activity.payload_converter()
+        )
+
         # Check for blocking verdicts from prior governance (signal or buffer)
         await self._check_pending_verdicts(info)
 
@@ -229,6 +237,7 @@ class _ActivityInterceptor(ActivityInboundInterceptor):
             governance_verdict = await self._send_activity_event(
                 info,
                 WorkflowEventType.ACTIVITY_STARTED.value,
+                multi_agent_session_id=session_id,
                 activity_input=activity_input,
             )
 
@@ -248,6 +257,9 @@ class _ActivityInterceptor(ActivityInboundInterceptor):
                 "attempt": info.attempt,
                 "activity_input": activity_input,
                 "activity_output": None,
+                # Hook events copy this context dict, so HTTP/DB/file events
+                # inherit the session id for free (omitempty).
+                **({"multi_agent_session_id": session_id} if session_id else {}),
             },
         )
 
@@ -269,6 +281,7 @@ class _ActivityInterceptor(ActivityInboundInterceptor):
         result = await self._handle_completion(
             info, status, error, start_time, end_time,
             activity_input, activity_output, result,
+            session_id,
         )
 
         return result
@@ -583,7 +596,7 @@ class _ActivityInterceptor(ActivityInboundInterceptor):
 
     async def _handle_completion(
         self, info, status, error, start_time, end_time,
-        activity_input, activity_output, result,
+        activity_input, activity_output, result, multi_agent_session_id=None,
     ) -> Any:
         """Send ActivityCompleted, enforce verdict, apply output redaction."""
         # Check abort/halt flags
@@ -620,6 +633,7 @@ class _ActivityInterceptor(ActivityInboundInterceptor):
             completed_verdict = await self._send_activity_event(
                 info,
                 WorkflowEventType.ACTIVITY_COMPLETED.value,
+                multi_agent_session_id=multi_agent_session_id,
                 status=status,
                 start_time=start_time,
                 end_time=end_time,
@@ -641,7 +655,7 @@ class _ActivityInterceptor(ActivityInboundInterceptor):
     # ─── Event sending ────────────────────────────────────────────────────
 
     async def _send_activity_event(
-        self, info, event_type: str, **extra
+        self, info, event_type: str, multi_agent_session_id=None, **extra
     ) -> Optional[GovernanceVerdictResponse]:
         """Send activity event via GovernanceClient."""
         serialized_extra = {}
@@ -663,6 +677,13 @@ class _ActivityInterceptor(ActivityInboundInterceptor):
             "task_queue": info.task_queue,
             "attempt": info.attempt,
             "timestamp": _rfc3339_now(),
+            # App-supplied multi-agent session id, propagated from the workflow
+            # header. Omitted entirely when absent (never a null key).
+            **(
+                {"multi_agent_session_id": multi_agent_session_id}
+                if multi_agent_session_id
+                else {}
+            ),
             **serialized_extra,
         }
 

--- a/openbox/multi_agent.py
+++ b/openbox/multi_agent.py
@@ -1,0 +1,139 @@
+# openbox/multi_agent.py
+"""Multi-agent primitives: handoff events + session-context propagation.
+
+The SDK does NOT own routing, session-id minting, or an agent registry — those
+are the application's responsibility. The app supplies the shared
+``multi_agent_session_id`` (via a workflow memo) and the SDK only propagates it
+onto the governance events it already emits, plus exposes ``emit_handoff`` for
+explicit agent-to-agent handoffs.
+
+Supply mechanism
+----------------
+- App sets ``memo={MEMO_KEY: session_id}`` at ``start_workflow(...)``.
+- The workflow interceptor reads it with ``workflow.memo_value`` (deterministic,
+  replay-safe) and tags workflow events with it.
+- The workflow outbound interceptor stamps it onto a Temporal ``HEADER_KEY``
+  header on every scheduled activity; the activity interceptor reads that header
+  and tags activity (and hook) events.
+
+SANDBOX SAFETY: this module is import-safe in the workflow sandbox — at module
+level it only imports ``temporalio.workflow``, and routes ``emit_handoff``
+through the existing ``send_governance_event`` activity (signing/HTTP happen in
+activity context, never in the workflow sandbox). Safe to export eagerly from
+``openbox/__init__.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional
+
+# App-facing memo key (start_workflow(memo={...})) → SDK reads on the workflow side.
+MEMO_KEY = "openbox_multi_agent_session_id"
+# Workflow → activity propagation header. Namespaced to avoid clashing with
+# Temporal's bundled TracingInterceptor headers.
+HEADER_KEY = "openbox-multi-agent-session-id"
+
+
+def _to_rfc3339(ts: datetime) -> str:
+    """Format a datetime as RFC3339 (UTC, millisecond precision, trailing Z)."""
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+# ─── Handoff ─────────────────────────────────────────────────────────────────
+
+
+def build_handoff_payload(
+    from_agent_did: str,
+    multi_agent_session_id: str,
+    ts: Optional[datetime] = None,
+) -> dict:
+    """Build + validate a Handoff event payload.
+
+    Both ``from_agent_did`` and ``multi_agent_session_id`` are required and
+    non-empty. Raises ``ValueError`` before any network call so misconfiguration
+    fails fast and locally.
+
+    Note: ``agent_did`` is deliberately NOT included — the receiver is derived
+    server-side from the authenticated signed identity, never sent.
+    """
+    if not from_agent_did or not from_agent_did.strip():
+        raise ValueError("emit_handoff: from_agent_did is required and must be non-empty")
+    if not multi_agent_session_id or not multi_agent_session_id.strip():
+        raise ValueError(
+            "emit_handoff: multi_agent_session_id is required and must be non-empty"
+        )
+
+    payload = {
+        "source": "workflow-telemetry",
+        "event_type": "Handoff",
+        "from_agent_did": from_agent_did,
+        "multi_agent_session_id": multi_agent_session_id,
+    }
+    if ts is not None:
+        # The activity uses setdefault, so an explicit timestamp is preserved.
+        payload["timestamp"] = _to_rfc3339(ts)
+    return payload
+
+
+async def emit_handoff(
+    multi_agent_session_id: str,
+    from_agent_did: str,
+    ts: Optional[datetime] = None,
+    *,
+    timeout: float = 30.0,
+    on_api_error: str = "fail_open",
+) -> Optional[dict]:
+    """Emit a multi-agent Handoff event from within a Temporal workflow.
+
+    Routes through the ``send_governance_event`` activity (which signs + sends),
+    keeping all crypto/HTTP off the workflow sandbox path. Call from workflow code.
+
+    Args:
+        multi_agent_session_id: Shared session id grouping the agents.
+        from_agent_did: DID of the agent handing off (the sender).
+        ts: Optional event timestamp; if omitted the activity stamps it.
+        timeout: Activity start-to-close budget (seconds).
+        on_api_error: "fail_open" or "fail_closed".
+
+    Returns:
+        The activity result dict (ALLOW verdict) or None on fail_open error.
+
+    Raises:
+        ValueError: if required fields are missing/empty.
+    """
+    payload = build_handoff_payload(from_agent_did, multi_agent_session_id, ts)
+
+    # Reuse the workflow-sandbox-safe activity dispatcher (no signing here).
+    from .workflow_interceptor import _send_governance_event
+
+    return await _send_governance_event(payload, timeout, on_api_error)
+
+
+# ─── Session-context propagation ───────────────────────────────────────────
+
+
+def read_session_from_memo() -> Optional[str]:
+    """Session id from the workflow memo, or None. Deterministic / replay-safe."""
+    from temporalio import workflow
+
+    return workflow.memo_value(MEMO_KEY, None)
+
+
+def inject_session_header(
+    headers: Mapping[str, Any], session_id: str, payload_converter: Any
+) -> dict:
+    """Return ``headers`` plus the session-id header (pure; caller passes converter)."""
+    return {**headers, HEADER_KEY: payload_converter.to_payload(session_id)}
+
+
+def read_session_from_header(
+    headers: Optional[Mapping[str, Any]], payload_converter: Any
+) -> Optional[str]:
+    """Session id from a Temporal headers mapping, or None."""
+    payload = headers.get(HEADER_KEY) if headers else None
+    if payload is None:
+        return None
+    return payload_converter.from_payload(payload, str)

--- a/openbox/types.py
+++ b/openbox/types.py
@@ -25,6 +25,7 @@ class WorkflowEventType(str, Enum):
     SIGNAL_RECEIVED = "SignalReceived"
     ACTIVITY_STARTED = "ActivityStarted"
     ACTIVITY_COMPLETED = "ActivityCompleted"
+    HANDOFF = "Handoff"
 
 
 class Verdict(str, Enum):

--- a/openbox/workflow_interceptor.py
+++ b/openbox/workflow_interceptor.py
@@ -24,9 +24,12 @@ from temporalio.exceptions import ActivityError, ApplicationError
 from temporalio.worker import (
     Interceptor,
     WorkflowInboundInterceptor,
+    WorkflowOutboundInterceptor,
     WorkflowInterceptorClassInput,
     ExecuteWorkflowInput,
     HandleSignalInput,
+    StartActivityInput,
+    StartLocalActivityInput,
 )
 
 from .errors import (
@@ -36,6 +39,7 @@ from .errors import (
     GOVERNANCE_STOP_ERROR_TYPE,
 )
 from .types import Verdict
+from .multi_agent import read_session_from_memo, inject_session_header
 
 
 def _application_error_type(exc: BaseException) -> Optional[str]:
@@ -241,13 +245,38 @@ class GovernanceInterceptor(Interceptor):
         skip_types = self.skip_workflow_types
         skip_sigs = self.skip_signals
 
+        class _Outbound(WorkflowOutboundInterceptor):
+            """Stamps the multi-agent session id onto every scheduled activity."""
+
+            def start_activity(self, input: StartActivityInput):
+                sid = read_session_from_memo()
+                if sid:
+                    input.headers = inject_session_header(
+                        input.headers, sid, workflow.payload_converter()
+                    )
+                return super().start_activity(input)
+
+            def start_local_activity(self, input: StartLocalActivityInput):
+                sid = read_session_from_memo()
+                if sid:
+                    input.headers = inject_session_header(
+                        input.headers, sid, workflow.payload_converter()
+                    )
+                return super().start_local_activity(input)
+
         class _Inbound(WorkflowInboundInterceptor):
+            def init(self, outbound: WorkflowOutboundInterceptor) -> None:
+                super().init(_Outbound(outbound))
+
             async def execute_workflow(self, input: ExecuteWorkflowInput) -> Any:
                 info = workflow.info()
 
                 # Skip if configured
                 if info.workflow_type in skip_types:
                     return await super().execute_workflow(input)
+
+                # Multi-agent session id from memo (app-supplied; omitempty).
+                sid = read_session_from_memo()
 
                 # WorkflowStarted event
                 if send_start and workflow.patched("openbox-v2-start"):
@@ -259,6 +288,7 @@ class GovernanceInterceptor(Interceptor):
                             "run_id": info.run_id,
                             "workflow_type": info.workflow_type,
                             "task_queue": info.task_queue,
+                            **({"multi_agent_session_id": sid} if sid else {}),
                         },
                         timeout,
                         on_error,
@@ -288,6 +318,7 @@ class GovernanceInterceptor(Interceptor):
                                 "run_id": info.run_id,
                                 "workflow_type": info.workflow_type,
                                 "workflow_output": workflow_output,
+                                **({"multi_agent_session_id": sid} if sid else {}),
                             },
                             timeout,
                             on_error,
@@ -310,6 +341,7 @@ class GovernanceInterceptor(Interceptor):
                                     "run_id": info.run_id,
                                     "workflow_type": info.workflow_type,
                                     "error": error,
+                                    **({"multi_agent_session_id": sid} if sid else {}),
                                 },
                                 timeout,
                                 on_error,
@@ -328,6 +360,7 @@ class GovernanceInterceptor(Interceptor):
 
                 # SignalReceived event - check verdict and store if "stop"
                 if workflow.patched("openbox-v2-signal"):
+                    sid = read_session_from_memo()
                     result = await _send_governance_event(
                         {
                             "source": "workflow-telemetry",
@@ -338,6 +371,7 @@ class GovernanceInterceptor(Interceptor):
                             "task_queue": info.task_queue,
                             "signal_name": input.signal,
                             "signal_args": input.args,
+                            **({"multi_agent_session_id": sid} if sid else {}),
                         },
                         timeout,
                         on_error,

--- a/tests/test_activity_interceptor.py
+++ b/tests/test_activity_interceptor.py
@@ -2580,3 +2580,109 @@ class TestHookLevelRequireApproval:
 
             assert exc_info.value.type == "ApprovalPending"
             assert exc_info.value.non_retryable is False
+
+
+# =============================================================================
+# Multi-Agent Session Propagation (activity side)
+# =============================================================================
+
+
+class TestActivityMultiAgentSession:
+    """Activity interceptor reads the session header and tags activity events."""
+
+    def _converter(self):
+        from temporalio.converter import default as _default_converter
+
+        return _default_converter().payload_converter
+
+    def _mock_tracer(self):
+        mock_span = MagicMock()
+        mock_span.get_span_context.return_value.trace_id = 123
+        mock_span.get_span_context.return_value.span_id = 456
+        mock_tracer = MagicMock()
+        mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(
+            return_value=mock_span
+        )
+        mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(
+            return_value=False
+        )
+        return mock_tracer
+
+    def _interceptor(self, mock_span_processor, mock_client):
+        mock_next = AsyncMock()
+        mock_next.execute_activity = AsyncMock(return_value="activity_result")
+        return _ActivityInterceptor(
+            next_interceptor=mock_next,
+            api_url="http://localhost:8086",
+            api_key="obx_test_key123",
+            span_processor=mock_span_processor,
+            config=GovernanceConfig(),
+            client=mock_client,
+        )
+
+    async def _run(self, mock_span_processor, mock_activity_info, headers):
+        from openbox.multi_agent import HEADER_KEY  # noqa: F401
+
+        conv = self._converter()
+        mock_client = MagicMock()
+        mock_client.evaluate_event = AsyncMock(return_value=None)
+        interceptor = self._interceptor(mock_span_processor, mock_client)
+
+        mock_input = MagicMock()
+        mock_input.args = []
+        mock_input.headers = headers
+
+        with (
+            patch("openbox.activity_interceptor.activity") as mock_activity,
+            patch("openbox.activity_interceptor.trace") as mock_trace,
+        ):
+            mock_activity.info.return_value = mock_activity_info
+            mock_activity.logger = MagicMock()
+            mock_activity.payload_converter.return_value = conv
+            mock_trace.get_tracer.return_value = self._mock_tracer()
+
+            await interceptor.execute_activity(mock_input)
+
+        event_payloads = {
+            call.args[0]["event_type"]: call.args[0]
+            for call in mock_client.evaluate_event.call_args_list
+        }
+        return event_payloads
+
+    @pytest.mark.asyncio
+    async def test_events_tagged_when_header_present(
+        self, mock_span_processor, mock_activity_info
+    ):
+        """Header present → ActivityStarted + ActivityCompleted carry the session id."""
+        conv = self._converter()
+        from openbox.multi_agent import HEADER_KEY
+
+        headers = {HEADER_KEY: conv.to_payload("sess-act")}
+        payloads = await self._run(mock_span_processor, mock_activity_info, headers)
+
+        assert payloads["ActivityStarted"]["multi_agent_session_id"] == "sess-act"
+        assert payloads["ActivityCompleted"]["multi_agent_session_id"] == "sess-act"
+
+    @pytest.mark.asyncio
+    async def test_events_not_tagged_when_header_absent(
+        self, mock_span_processor, mock_activity_info
+    ):
+        """Header absent → multi_agent_session_id omitted from both events."""
+        payloads = await self._run(mock_span_processor, mock_activity_info, {})
+
+        assert "multi_agent_session_id" not in payloads["ActivityStarted"]
+        assert "multi_agent_session_id" not in payloads["ActivityCompleted"]
+
+    @pytest.mark.asyncio
+    async def test_activity_context_carries_session_id_for_hooks(
+        self, mock_span_processor, mock_activity_info
+    ):
+        """Buffered activity context carries the id so hook events inherit it."""
+        conv = self._converter()
+        from openbox.multi_agent import HEADER_KEY
+
+        headers = {HEADER_KEY: conv.to_payload("sess-hook")}
+        await self._run(mock_span_processor, mock_activity_info, headers)
+
+        ctx = mock_span_processor.set_activity_context.call_args.args[2]
+        assert ctx["multi_agent_session_id"] == "sess-hook"

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -1,0 +1,133 @@
+"""Tests for openbox.multi_agent: handoff payloads, emit_handoff, session headers."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from temporalio.converter import default as _default_converter
+
+from openbox import emit_handoff
+from openbox.types import WorkflowEventType
+from openbox.multi_agent import (
+    MEMO_KEY,
+    HEADER_KEY,
+    build_handoff_payload,
+    inject_session_header,
+    read_session_from_header,
+)
+
+
+def _converter():
+    return _default_converter().payload_converter
+
+
+# ─── Event type ──────────────────────────────────────────────────────────────
+
+
+def test_handoff_event_type_value():
+    assert WorkflowEventType.HANDOFF == "Handoff"
+    assert WorkflowEventType.HANDOFF.value == "Handoff"
+
+
+# ─── build_handoff_payload ─────────────────────────────────────────────────────
+
+
+def test_build_handoff_payload_minimal():
+    payload = build_handoff_payload("did:aip:sender", "sess-123")
+    assert payload == {
+        "source": "workflow-telemetry",
+        "event_type": "Handoff",
+        "from_agent_did": "did:aip:sender",
+        "multi_agent_session_id": "sess-123",
+    }
+    # Receiver is derived server-side — never sent.
+    assert "agent_did" not in payload
+
+
+def test_build_handoff_payload_with_timestamp():
+    ts = datetime(2026, 5, 27, 12, 0, 0, 500000, tzinfo=timezone.utc)
+    payload = build_handoff_payload("did:aip:sender", "sess-123", ts)
+    assert payload["timestamp"] == "2026-05-27T12:00:00.500Z"
+
+
+@pytest.mark.parametrize(
+    "from_did, session_id",
+    [
+        ("", "sess"),
+        ("   ", "sess"),
+        ("did:aip:sender", ""),
+        ("did:aip:sender", "   "),
+        (None, "sess"),
+        ("did:aip:sender", None),
+    ],
+)
+def test_build_handoff_payload_rejects_empty(from_did, session_id):
+    with pytest.raises(ValueError):
+        build_handoff_payload(from_did, session_id)
+
+
+# ─── emit_handoff ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_emit_handoff_routes_through_activity_dispatcher():
+    sender = AsyncMock(return_value={"verdict": "allow"})
+    with patch(
+        "openbox.workflow_interceptor._send_governance_event", sender
+    ):
+        result = await emit_handoff(
+            multi_agent_session_id="sess-123",
+            from_agent_did="did:aip:sender",
+            timeout=12.0,
+            on_api_error="fail_closed",
+        )
+
+    assert result == {"verdict": "allow"}
+    sender.assert_awaited_once()
+    payload, timeout, on_api_error = sender.await_args.args
+    assert payload["event_type"] == "Handoff"
+    assert payload["from_agent_did"] == "did:aip:sender"
+    assert payload["multi_agent_session_id"] == "sess-123"
+    assert timeout == 12.0
+    assert on_api_error == "fail_closed"
+
+
+@pytest.mark.asyncio
+async def test_emit_handoff_validates_before_network():
+    sender = AsyncMock()
+    with patch("openbox.workflow_interceptor._send_governance_event", sender):
+        with pytest.raises(ValueError):
+            await emit_handoff(multi_agent_session_id="", from_agent_did="did:aip:x")
+    sender.assert_not_awaited()
+
+
+# ─── session header round-trip ──────────────────────────────────────────────────
+
+
+def test_inject_and_read_session_header_round_trip():
+    conv = _converter()
+    headers = inject_session_header({}, "sess-xyz", conv)
+    assert HEADER_KEY in headers
+    assert read_session_from_header(headers, conv) == "sess-xyz"
+
+
+def test_inject_session_header_preserves_existing():
+    conv = _converter()
+    existing = {"other": conv.to_payload("keep")}
+    headers = inject_session_header(existing, "sess", conv)
+    assert "other" in headers
+    assert HEADER_KEY in headers
+
+
+def test_read_session_from_header_none_and_empty():
+    conv = _converter()
+    assert read_session_from_header(None, conv) is None
+    assert read_session_from_header({}, conv) is None
+    assert read_session_from_header({"unrelated": conv.to_payload("x")}, conv) is None
+
+
+def test_memo_and_header_keys_are_distinct():
+    # Memo key is app-facing; header key is internal wire propagation.
+    assert MEMO_KEY == "openbox_multi_agent_session_id"
+    assert HEADER_KEY == "openbox-multi-agent-session-id"
+    assert MEMO_KEY != HEADER_KEY

--- a/tests/test_workflow_interceptor.py
+++ b/tests/test_workflow_interceptor.py
@@ -554,7 +554,9 @@ class TestInboundInterceptor:
     @pytest.fixture
     def mock_workflow_module(self, mock_workflow_info):
         """Create a mock workflow module with patched methods."""
-        with patch("openbox.workflow_interceptor.workflow") as mock:
+        with patch("openbox.workflow_interceptor.workflow") as mock, patch(
+            "openbox.workflow_interceptor.read_session_from_memo", return_value=None
+        ):
             mock.info.return_value = mock_workflow_info
             mock.patched.return_value = True
             mock.execute_activity = AsyncMock(return_value={"verdict": "allow"})
@@ -1210,7 +1212,9 @@ class TestInterceptorClosures:
     @pytest.mark.asyncio
     async def test_interceptor_captures_config_values(self):
         """Test that the inner _Inbound class captures config values via closures."""
-        with patch("openbox.workflow_interceptor.workflow") as mock_workflow:
+        with patch("openbox.workflow_interceptor.workflow") as mock_workflow, patch(
+            "openbox.workflow_interceptor.read_session_from_memo", return_value=None
+        ):
             mock_info = MagicMock()
             mock_info.workflow_id = "wf-closure-test"
             mock_info.run_id = "run-closure"
@@ -1301,7 +1305,9 @@ class TestEdgeCases:
     @pytest.mark.asyncio
     async def test_execute_workflow_handles_none_result(self):
         """Test execute_workflow handles None result."""
-        with patch("openbox.workflow_interceptor.workflow") as mock_workflow:
+        with patch("openbox.workflow_interceptor.workflow") as mock_workflow, patch(
+            "openbox.workflow_interceptor.read_session_from_memo", return_value=None
+        ):
             mock_info = MagicMock()
             mock_info.workflow_id = "wf-none"
             mock_info.run_id = "run-none"
@@ -1342,7 +1348,9 @@ class TestEdgeCases:
     @pytest.mark.asyncio
     async def test_handle_signal_with_empty_args(self):
         """Test handle_signal with empty args list."""
-        with patch("openbox.workflow_interceptor.workflow") as mock_workflow:
+        with patch("openbox.workflow_interceptor.workflow") as mock_workflow, patch(
+            "openbox.workflow_interceptor.read_session_from_memo", return_value=None
+        ):
             mock_info = MagicMock()
             mock_info.workflow_id = "wf-signal"
             mock_info.run_id = "run-signal"
@@ -1383,3 +1391,182 @@ class TestEdgeCases:
             api_key="test-key",
         )
         assert isinstance(interceptor, Interceptor)
+
+
+# =============================================================================
+# Multi-Agent Session Propagation (workflow side)
+# =============================================================================
+
+
+class TestMultiAgentSessionPropagation:
+    """Workflow interceptor tags events + stamps header from the memo session id."""
+
+    def _interceptor(self):
+        return GovernanceInterceptor(
+            api_url="https://api.openbox.ai",
+            api_key="test-key",
+            span_processor=MagicMock(),
+            config=GovernanceConfig(),
+        )
+
+    def _mock_info(self):
+        info = MagicMock()
+        info.workflow_id = "wf-ma"
+        info.run_id = "run-ma"
+        info.workflow_type = "MaWorkflow"
+        info.task_queue = "ma-queue"
+        return info
+
+    @pytest.mark.asyncio
+    async def test_workflow_events_tagged_when_memo_set(self):
+        """Memo set → WorkflowStarted/Completed payloads carry multi_agent_session_id."""
+        with patch("openbox.workflow_interceptor.workflow") as mock_wf, patch(
+            "openbox.workflow_interceptor.read_session_from_memo",
+            return_value="sess-abc",
+        ):
+            mock_wf.info.return_value = self._mock_info()
+            mock_wf.patched.return_value = True
+            mock_wf.execute_activity = AsyncMock(return_value={"verdict": "allow"})
+
+            inbound_class = self._interceptor().workflow_interceptor_class(MagicMock())
+            mock_next = AsyncMock()
+            mock_next.execute_workflow = AsyncMock(return_value="ok")
+            inbound = inbound_class(mock_next)
+
+            await inbound.execute_workflow(MagicMock())
+
+            payloads = [
+                c.kwargs["args"][0]["payload"]
+                for c in mock_wf.execute_activity.call_args_list
+            ]
+            assert payloads, "expected at least one governance event"
+            for payload in payloads:
+                assert payload["multi_agent_session_id"] == "sess-abc"
+
+    @pytest.mark.asyncio
+    async def test_workflow_failed_tagged_when_memo_set(self):
+        """Memo set → WorkflowFailed payload carries multi_agent_session_id."""
+        with patch("openbox.workflow_interceptor.workflow") as mock_wf, patch(
+            "openbox.workflow_interceptor.read_session_from_memo",
+            return_value="sess-abc",
+        ):
+            mock_wf.info.return_value = self._mock_info()
+            mock_wf.patched.return_value = True
+            mock_wf.execute_activity = AsyncMock(return_value={"verdict": "allow"})
+
+            inbound_class = self._interceptor().workflow_interceptor_class(MagicMock())
+            mock_next = AsyncMock()
+            mock_next.execute_workflow = AsyncMock(side_effect=ValueError("boom"))
+            inbound = inbound_class(mock_next)
+
+            with pytest.raises(ValueError):
+                await inbound.execute_workflow(MagicMock())
+
+            failed = [
+                c.kwargs["args"][0]["payload"]
+                for c in mock_wf.execute_activity.call_args_list
+                if c.kwargs["args"][0]["payload"]["event_type"] == "WorkflowFailed"
+            ]
+            assert failed and failed[0]["multi_agent_session_id"] == "sess-abc"
+
+    @pytest.mark.asyncio
+    async def test_signal_tagged_when_memo_set(self):
+        """Memo set → SignalReceived payload carries multi_agent_session_id."""
+        with patch("openbox.workflow_interceptor.workflow") as mock_wf, patch(
+            "openbox.workflow_interceptor.read_session_from_memo",
+            return_value="sess-abc",
+        ):
+            mock_wf.info.return_value = self._mock_info()
+            mock_wf.patched.return_value = True
+            mock_wf.execute_activity = AsyncMock(return_value={"verdict": "allow"})
+
+            inbound_class = self._interceptor().workflow_interceptor_class(MagicMock())
+            mock_next = AsyncMock()
+            mock_next.handle_signal = AsyncMock()
+            inbound = inbound_class(mock_next)
+
+            signal_input = MagicMock()
+            signal_input.signal = "sig"
+            signal_input.args = []
+            await inbound.handle_signal(signal_input)
+
+            payload = mock_wf.execute_activity.call_args_list[0].kwargs["args"][0][
+                "payload"
+            ]
+            assert payload["multi_agent_session_id"] == "sess-abc"
+
+    @pytest.mark.asyncio
+    async def test_events_not_tagged_when_memo_absent(self):
+        """Memo absent → no multi_agent_session_id key in any payload."""
+        with patch("openbox.workflow_interceptor.workflow") as mock_wf, patch(
+            "openbox.workflow_interceptor.read_session_from_memo", return_value=None
+        ):
+            mock_wf.info.return_value = self._mock_info()
+            mock_wf.patched.return_value = True
+            mock_wf.execute_activity = AsyncMock(return_value={"verdict": "allow"})
+
+            inbound_class = self._interceptor().workflow_interceptor_class(MagicMock())
+            mock_next = AsyncMock()
+            mock_next.execute_workflow = AsyncMock(return_value="ok")
+            inbound = inbound_class(mock_next)
+
+            await inbound.execute_workflow(MagicMock())
+
+            for c in mock_wf.execute_activity.call_args_list:
+                payload = c.kwargs["args"][0]["payload"]
+                assert "multi_agent_session_id" not in payload
+
+    @pytest.mark.asyncio
+    async def test_outbound_stamps_header_when_memo_set(self):
+        """Outbound interceptor stamps HEADER_KEY on scheduled activities."""
+        from temporalio.converter import default as _default_converter
+        from openbox.multi_agent import HEADER_KEY
+
+        conv = _default_converter().payload_converter
+        with patch("openbox.workflow_interceptor.workflow") as mock_wf, patch(
+            "openbox.workflow_interceptor.read_session_from_memo",
+            return_value="sess-out",
+        ):
+            mock_wf.payload_converter.return_value = conv
+
+            inbound_class = self._interceptor().workflow_interceptor_class(MagicMock())
+
+            # Capture the _Outbound instance the inbound wraps during init().
+            captured = {}
+            mock_next = MagicMock()
+            mock_next.init = lambda outbound: captured.__setitem__("outbound", outbound)
+            inbound = inbound_class(mock_next)
+            inbound.init(MagicMock())
+            outbound = captured["outbound"]
+
+            activity_input = MagicMock()
+            activity_input.headers = {}
+            outbound.start_activity(activity_input)
+
+            assert HEADER_KEY in activity_input.headers
+            assert (
+                conv.from_payload(activity_input.headers[HEADER_KEY], str)
+                == "sess-out"
+            )
+
+    @pytest.mark.asyncio
+    async def test_outbound_no_header_when_memo_absent(self):
+        """Outbound interceptor leaves headers untouched when no session id."""
+        from openbox.multi_agent import HEADER_KEY
+
+        with patch("openbox.workflow_interceptor.workflow"), patch(
+            "openbox.workflow_interceptor.read_session_from_memo", return_value=None
+        ):
+            inbound_class = self._interceptor().workflow_interceptor_class(MagicMock())
+            captured = {}
+            mock_next = MagicMock()
+            mock_next.init = lambda outbound: captured.__setitem__("outbound", outbound)
+            inbound = inbound_class(mock_next)
+            inbound.init(MagicMock())
+            outbound = captured["outbound"]
+
+            activity_input = MagicMock()
+            activity_input.headers = {}
+            outbound.start_activity(activity_input)
+
+            assert HEADER_KEY not in activity_input.headers


### PR DESCRIPTION
## Summary

Adds multi-agent session-context propagation and an explicit handoff primitive. The SDK only **propagates** an app-supplied `multi_agent_session_id` — it never invents one, and owns no routing, session minting, or agent registry.

- App supplies the id via workflow memo `openbox_multi_agent_session_id` at `start_workflow(memo={...})`.
- Workflow interceptor reads it (`workflow.memo_value`, replay-safe) and tags WorkflowStarted/Completed/Failed/SignalReceived (omitempty).
- A workflow outbound interceptor stamps the id onto a Temporal header on each scheduled activity; the activity interceptor reads it and tags ActivityStarted/ActivityCompleted, plus writes it into the activity context so HTTP/DB/file hook events inherit it.
- New `emit_handoff(multi_agent_session_id=..., from_agent_did=...)` emits a signed `Handoff` event; receiver is derived server-side from the signed identity and never sent.
- New `WorkflowEventType.HANDOFF`; all multi-agent code in sandbox-safe `openbox/multi_agent.py`, eagerly exported.

No worker/plugin signature changes.

## Tests

New `tests/test_multi_agent.py` plus propagation cases in the workflow/activity interceptor suites. Full suite: **837 passed**.

## Docs

README event-types table + "Multi-Agent Sessions" section; `docs/configuration.md` memo-based multi-agent section.

## Notes

- Version bump and lockfile changes are intentionally left out of this PR.
- Child-workflow header propagation is out of scope (direct + local activities only).
